### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -8,6 +8,8 @@ import subprocess
 import config
 
 app = Flask(__name__)
+import logging
+logging.basicConfig(level=logging.ERROR)
 app.config.from_object(config.Config)
 
 CORS(app, resources={r'/*': {'origins': '*'}})
@@ -39,8 +41,8 @@ def music():
         return jsonify(data), 200
 
     except Exception as msg:
-        data = {'error': '{}: {}'.format(type(msg), msg)}
-        return jsonify(data), 400
+        app.logger.error('An error occurred in /music: %s', msg, exc_info=True)
+        return jsonify({'error': 'An internal error has occurred. Please try again later.'}), 400
 
 @app.route('/resume', methods=['GET'])
 def resume():


### PR DESCRIPTION
Potential fix for [https://github.com/jon77p/jonprentice.me/security/code-scanning/2](https://github.com/jon77p/jonprentice.me/security/code-scanning/2)

To fix the issue, we will replace the detailed error message with a generic one that does not expose sensitive information. The exception details will be logged on the server for debugging purposes. This ensures that developers can still access the error information while preventing its exposure to end users.

- Modify the `except` block in the `/music` route to log the exception details and return a generic error message to the user.
- Add a logging mechanism to capture the exception details. The `logging` module will be used for this purpose.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
